### PR TITLE
Fix replace_dup_emoji which removes dup numbers

### DIFF
--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -53,6 +53,7 @@ class Test_preprocess(object):
         self.emoji_text = "🌈อย่าฟอล เดี๋ยวจน🌻รีวิวในแท็ก"
         self.noodle_text = "˚┉┉┉┉┉༝✧ คิดว่าน่าจะเหลือแค่ภาษาไทย กับ ˢʰᵉ 𝙧𝙖𝙩𝙘𝙝𝙖𝙙𝙖𝙥𝙞𝙨𝙚𝙠 English และ  ﾏﾝﾎﾞﾏﾝﾎﾞ．．．ນະຄອນຫລ🤔🤔🤔🤔ວງ．ﺍﻟﻘﻔﺺ🤣"
         self.dup_emojis_text = "อ้ายอ้วน😣😣"
+        self.dup_emojis_text_with_dup_numbers = "👧👧👧👧👧👧 111111 3️⃣3️⃣3️⃣3️⃣3️⃣3️⃣"
         self.complex_text = " ".join(
             [
                 self.tag_text,
@@ -178,3 +179,8 @@ class Test_preprocess(object):
     def test_replace_dup_emojis(self):
         expected_result = "อ้ายอ้วน😣"
         assert_equal(replace_dup_emojis(self.dup_emojis_text), expected_result)
+
+    def test_replace_dup_emojis_with_dup_numbers(self):
+        expected_result = "👧 111111 3️⃣"
+        assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
+        

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -96,7 +96,7 @@ RE_NONTHAI_ENG_EMOJI = re.compile(
 
 # Any non-whitesplace character and non-digits duplication
 RE_DUP_CHARS = re.compile(r"([^0-9๐-๙\s])(\1{2,})")
-RE_DUP_EMOJIS = re.compile(r"([{}])(\1{})".format(RE_EMOJI.pattern, "{1,}"))
+RE_DUP_EMOJIS = re.compile(r"{}(\1{})".format(RE_EMOJI.pattern, "{1,}"))
 
 
 def is_date_str(var) -> bool:


### PR DESCRIPTION
Issue:
```
replace_dup_emojis("👧👧👧👧👧👧 1111122223334444444443️⃣3️⃣")
>>👧12343️⃣
```

Fixed:
```
replace_dup_emojis("👧👧👧👧👧👧 1111122223334444444443️⃣3️⃣")
>>👧1111122223334444444443️⃣
```

Caution:
```
replace_dup_emojis(👧👧👧👧👧👧👧🏻👧🏻👧🏻👧🏻👧🏻👧🏻👧🏻👧🏻)
>>👧🏻👧🏻
```