### PR TITLE
Fix/normalize at mention

### DIFF
--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -109,6 +109,21 @@ class Test_preprocess(object):
         expected_result = " WSNAME "
         assert_equal(normalize_at_mention(self.mention_text), expected_result)
 
+    def test_normalize_at_mention_with_non_whitespace(self):
+        text = "twitter:@wisesight @123456 (มี@ด้วย)"
+        expected_result = "twitter: WSNAME   WSNAME  (มี WSNAME )"
+        assert_equal(normalize_at_mention(text), expected_result)
+
+    def test_normalize_at_mention_with_punctuation(self):
+        text = "This is not a mention in social media messages but it has to be cleaned: @#$%^@#$%^&"
+        expected_result = "This is not a mention in social media messages but it has to be cleaned:  WSNAME "
+        assert_equal(normalize_at_mention(text), expected_result)
+
+    def test_normalize_at_mention_email(self):
+        text = "email: example@something.com"
+        expected_result = "email: example@something.com"
+        assert_equal(normalize_at_mention(text), expected_result)
+
     def test_normalize_email(self):
         expected_result = " WSEMAIL "
         assert_equal(normalize_email(self.email_text), expected_result)
@@ -183,8 +198,12 @@ class Test_preprocess(object):
 
     def test_replace_dup_emojis_with_dup_numbers(self):
         expected_result = "👧 111111 3️⃣"
-        assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
-        
+        assert_equal(
+            replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result
+        )
+
     def test_normalize_at_mention_with_non_whitespace(self):
         expected_result = "twitter: WSNAME "
-        assert_equal(normalize_at_mention(self.mention_text_with_non_whitespace), expected_result)
+        assert_equal(
+            normalize_at_mention(self.mention_text_with_non_whitespace), expected_result
+        )

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -54,6 +54,7 @@ class Test_preprocess(object):
         self.noodle_text = "˚┉┉┉┉┉༝✧ คิดว่าน่าจะเหลือแค่ภาษาไทย กับ ˢʰᵉ 𝙧𝙖𝙩𝙘𝙝𝙖𝙙𝙖𝙥𝙞𝙨𝙚𝙠 English และ  ﾏﾝﾎﾞﾏﾝﾎﾞ．．．ນະຄອນຫລ🤔🤔🤔🤔ວງ．ﺍﻟﻘﻔﺺ🤣"
         self.dup_emojis_text = "อ้ายอ้วน😣😣"
         self.dup_emojis_text_with_dup_numbers = "👧👧👧👧👧👧 111111 3️⃣3️⃣3️⃣3️⃣3️⃣3️⃣"
+        self.mention_text_with_non_whitespace = "twitter:@wisesight"
         self.complex_text = " ".join(
             [
                 self.tag_text,
@@ -184,3 +185,6 @@ class Test_preprocess(object):
         expected_result = "👧 111111 3️⃣"
         assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
         
+    def test_normalize_at_mention_with_non_whitespace(self):
+        expected_result = "twitter: WSNAME "
+        assert_equal(normalize_at_mention(self.mention_text_with_non_whitespace), expected_result)

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -42,7 +42,7 @@ RE_EXT = re.compile(
     r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
     flags=re.IGNORECASE,
 )
-RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
+RE_AT_MENTION = re.compile(r"(?<=^|(?<=[^a-zA-Z0-9-_\.]))@[^\s()\[\]{}<>]+")
 RE_EMAIL = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b")
 RE_HAHA = re.compile(r"\b(?:ha\s*){2,}|\u0E16{3,}|5{3,}(?!.\d)\b", flags=re.IGNORECASE)
 RE_HASHTAGS = re.compile(r"#([a-zA-Zก-๛0-9]+[a-zA-Zก-๛0-9]*)")


### PR DESCRIPTION
### Issue:
```
normalize_at_mention("twitter:@wisesight")
>>'twitter:@wisesight'
```

### Fixed:
```
normalize_at_mention("twitter:@wisesight")
>>'twitter: WSNAME '
```

### Caution:
Non-ascii email format is considered as a mention by the fixed regex.

```
 ## this is working properly

normalize_at_mention("example@example.com @example")
>>'example@example.com  WSNAME '

## @例子.广告 was considered a mention

normalize_at_mention("用户@例子.广告 @example")
>>'用户 WSNAME   WSNAME ' 
```