### PR TITLE
update normalize_link for links without www

### DIFF
--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -15,6 +15,7 @@ from th_preprocessor.preprocess import (
     normalize_emoji,
     normalize_haha,
     normalize_link,
+    normalize_link_with_extension,
     normalize_num,
     normalize_phone,
     normalize_special_chars,
@@ -41,6 +42,8 @@ class Test_preprocess(object):
         self.mix_text = "hey123ไม่ได้เป็นคนที่เกเรyoyo&แฮ่&&hello"
         self.unnorm_text = "เเําฤาฦา๑๒๓๔๕๖๗๘๙๐,.=\0\r\n\t\u00A0" + string.punctuation
         self.link_text = "http://www.youtube.com"
+        self.link_text_without_protocol = "google.com/search?q=hello"
+        self.link_with_extension = "https://en.wikipedia.org/wiki/Apple_Inc.#/media/File:Apple_logo_black.svg logo.svg"
         self.mention_text = "@test1234"
         self.email_text = "test_eiei_za@gmail.com"
         self.haha_text = "555555"
@@ -104,6 +107,12 @@ class Test_preprocess(object):
     def test_normalize_link(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text), expected_result)
+        expected_result = " WSLINK "
+        assert_equal(normalize_link(self.link_text_without_protocol), expected_result)
+    
+    def test_normalize_link_with_extension(self):
+        expected_result = " WSLINK   WSLINK "
+        assert_equal(normalize_link_with_extension(self.link_with_extension), expected_result)
 
     def test_normalize_at_mention(self):
         expected_result = " WSNAME "

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -109,6 +109,21 @@ class Test_preprocess(object):
         expected_result = " WSNAME "
         assert_equal(normalize_at_mention(self.mention_text), expected_result)
 
+    def test_normalize_at_mention_with_non_whitespace(self):
+        text = "twitter:@wisesight @123456 (มี@ด้วย)"
+        expected_result = "twitter: WSNAME   WSNAME  (มี WSNAME )"
+        assert_equal(normalize_at_mention(text), expected_result)
+
+    def test_normalize_at_mention_with_punctuation(self):
+        text = "This is not a mention in social media messages but it has to be cleaned: @#$%^@#$%^&"
+        expected_result = "This is not a mention in social media messages but it has to be cleaned:  WSNAME "
+        assert_equal(normalize_at_mention(text), expected_result)
+
+    def test_normalize_at_mention_email(self):
+        text = "email: example@something.com"
+        expected_result = "email: example@something.com"
+        assert_equal(normalize_at_mention(text), expected_result)
+
     def test_normalize_email(self):
         expected_result = " WSEMAIL "
         assert_equal(normalize_email(self.email_text), expected_result)
@@ -183,8 +198,12 @@ class Test_preprocess(object):
 
     def test_replace_dup_emojis_with_dup_numbers(self):
         expected_result = "👧 111111 3️⃣"
-        assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
-        
+        assert_equal(
+            replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result
+        )
+
     def test_normalize_at_mention_with_non_whitespace(self):
         expected_result = "twitter: WSNAME "
-        assert_equal(normalize_at_mention(self.mention_text_with_non_whitespace), expected_result)
+        assert_equal(
+            normalize_at_mention(self.mention_text_with_non_whitespace), expected_result
+        )

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -54,6 +54,7 @@ class Test_preprocess(object):
         self.noodle_text = "˚┉┉┉┉┉༝✧ คิดว่าน่าจะเหลือแค่ภาษาไทย กับ ˢʰᵉ 𝙧𝙖𝙩𝙘𝙝𝙖𝙙𝙖𝙥𝙞𝙨𝙚𝙠 English และ  ﾏﾝﾎﾞﾏﾝﾎﾞ．．．ນະຄອນຫລ🤔🤔🤔🤔ວງ．ﺍﻟﻘﻔﺺ🤣"
         self.dup_emojis_text = "อ้ายอ้วน😣😣"
         self.dup_emojis_text_with_dup_numbers = "👧👧👧👧👧👧 111111 3️⃣3️⃣3️⃣3️⃣3️⃣3️⃣"
+        self.mention_text_with_non_whitespace = "twitter:@wisesight"
         self.complex_text = " ".join(
             [
                 self.tag_text,
@@ -184,3 +185,6 @@ class Test_preprocess(object):
         expected_result = "👧 111111 3️⃣"
         assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
         
+    def test_normalize_at_mention_with_non_whitespace(self):
+        expected_result = "twitter: WSNAME "
+        assert_equal(normalize_at_mention(self.mention_text_with_non_whitespace), expected_result)

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -48,12 +48,6 @@ class Test_preprocess(object):
         self.special_text = "𝑇ℎ𝑒 𝑚𝑜𝑠𝑡 𝑖𝑚𝑝𝑜𝑟𝑡𝑎𝑛𝑡 𝑡ℎ𝑖𝑛𝑔 𝑖𝑠 𝑡𝑜 𝑒𝑛𝑗𝑜𝑦 น้าทุกคน"
         self.accented_text = "Cześć NESCAFÉ"
         self.hashtags_text = "Saturday be like this #pinklover #purplehair #isseymiyake #baobaoisseymiyake #baobaothailand #cafe"
-        self.hashtags_text_with_underscore = (
-            "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม #covid19 #covid_19 #covid-19"
-        )
-        self.hashtags_number = "Biomutant #1 ไทย - ไอขน คนเท่!"
-        self.hashtags_text_with_number = "สวัสดีปีกุน #สวัสดี5555"
-        self.hashtags_number_with_text = "สวัสดีปีระกา #5555สวัสดี"
         self.tag_text = "<div>Test HTML</div>"
         self.dup_space_text = "นอนได้แล้ว\n\n\n\n\nเดี๋ยวพรุ่งนี้เขาก็กลับมา"
         self.emoji_text = "🌈อย่าฟอล เดี๋ยวจน🌻รีวิวในแท็ก"
@@ -147,18 +141,33 @@ class Test_preprocess(object):
         assert_equal(remove_hashtags(self.hashtags_text), expected_result)
 
     def test_remove_hashtags_with_underscore(self):
+        text = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม #covid19 #covid_19 #covid-19"
         expected_result = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม   "
-        assert_equal(
-            remove_hashtags(self.hashtags_text_with_underscore), expected_result
+        assert_equal(remove_hashtags(text), expected_result)
+
+    def test_remove_hashtags_with_punctuation(self):
+        text = "ฉลองครบรอบ #เซลใหญ่วันเกิด10ปี@Lazada พบทีเด็ดแบรนด์ดังแจกรางวัลสุดปัง รวมมูลค่ากว่า 3,300,000 บาท"
+        expected_result = (
+            "ฉลองครบรอบ  พบทีเด็ดแบรนด์ดังแจกรางวัลสุดปัง รวมมูลค่ากว่า 3,300,000 บาท"
         )
+        assert_equal(remove_hashtags(text), expected_result)
+
+    def test_remove_hashtags_with_punctuation_only(self):
+        text = "ฉลองครบรอบ #%@&^%!%^%@^% พบทีเด็ดแบรนด์ดังแจกรางวัลสุดปัง รวมมูลค่ากว่า 3,300,000 บาท"
+        expected_result = (
+            "ฉลองครบรอบ  พบทีเด็ดแบรนด์ดังแจกรางวัลสุดปัง รวมมูลค่ากว่า 3,300,000 บาท"
+        )
+        assert_equal(remove_hashtags(text), expected_result)
 
     def test_remove_hashtags_text_with_number(self):
+        text = "สวัสดีปีกุน #สวัสดี5555"
         expected_result = "สวัสดีปีกุน "
-        assert_equal(remove_hashtags(self.hashtags_text_with_number), expected_result)
+        assert_equal(remove_hashtags(text), expected_result)
 
     def test_remove_hashtags_number_with_text(self):
+        text = "สวัสดีปีระกา #5555สวัสดี"
         expected_result = "สวัสดีปีระกา "
-        assert_equal(remove_hashtags(self.hashtags_number_with_text), expected_result)
+        assert_equal(remove_hashtags(text), expected_result)
 
     def test_remove_tag(self):
         expected_result = "Test HTML"

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -13,9 +13,9 @@ from th_preprocessor.preprocess import (
     normalize_at_mention,
     normalize_email,
     normalize_emoji,
+    normalize_filename,
     normalize_haha,
     normalize_link,
-    normalize_link_with_extension,
     normalize_num,
     normalize_phone,
     normalize_special_chars,
@@ -43,7 +43,7 @@ class Test_preprocess(object):
         self.unnorm_text = "เเําฤาฦา๑๒๓๔๕๖๗๘๙๐,.=\0\r\n\t\u00A0" + string.punctuation
         self.link_text = "http://www.youtube.com"
         self.link_text_without_protocol = "google.com/search?q=hello"
-        self.link_with_extension = "https://en.wikipedia.org/wiki/Apple_Inc.#/media/File:Apple_logo_black.svg logo.svg"
+        self.filename_text = "logo.png"
         self.mention_text = "@test1234"
         self.email_text = "test_eiei_za@gmail.com"
         self.haha_text = "555555"
@@ -107,12 +107,27 @@ class Test_preprocess(object):
     def test_normalize_link(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text), expected_result)
+
+    def test_normalize_link_without_protocol(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text_without_protocol), expected_result)
-    
-    def test_normalize_link_with_extension(self):
-        expected_result = " WSLINK   WSLINK "
-        assert_equal(normalize_link_with_extension(self.link_with_extension), expected_result)
+
+    def test_normalize_link_text_with_dot(self):
+        text = "This is a book.This is a cat."
+        expected_result = "This is a book.This is a cat."
+        assert_equal(normalize_link(text), expected_result)
+
+    def test_normalize_link_email(self):
+        text = "foo.b@gmail.com"
+        expected_result = "foo.b@gmail.com"
+        assert_equal(normalize_link(text), expected_result)
+        text = "foo_foo@gmail.com"
+        expected_result = "foo_foo@gmail.com"
+        assert_equal(normalize_link(text), expected_result)
+
+    def test_normalize_filename(self):
+        expected_result = " WSFILENAME "
+        assert_equal(normalize_filename(self.filename_text), expected_result)
 
     def test_normalize_at_mention(self):
         expected_result = " WSNAME "

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -48,7 +48,12 @@ class Test_preprocess(object):
         self.special_text = "𝑇ℎ𝑒 𝑚𝑜𝑠𝑡 𝑖𝑚𝑝𝑜𝑟𝑡𝑎𝑛𝑡 𝑡ℎ𝑖𝑛𝑔 𝑖𝑠 𝑡𝑜 𝑒𝑛𝑗𝑜𝑦 น้าทุกคน"
         self.accented_text = "Cześć NESCAFÉ"
         self.hashtags_text = "Saturday be like this #pinklover #purplehair #isseymiyake #baobaoisseymiyake #baobaothailand #cafe"
-        self.hashtags_text_with_underscore = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม #covid19 #covid_19 #covid-19"
+        self.hashtags_text_with_underscore = (
+            "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม #covid19 #covid_19 #covid-19"
+        )
+        self.hashtags_number = "Biomutant #1 ไทย - ไอขน คนเท่!"
+        self.hashtags_text_with_number = "สวัสดีปีกุน #สวัสดี5555"
+        self.hashtags_number_with_text = "สวัสดีปีระกา #5555สวัสดี"
         self.tag_text = "<div>Test HTML</div>"
         self.dup_space_text = "นอนได้แล้ว\n\n\n\n\nเดี๋ยวพรุ่งนี้เขาก็กลับมา"
         self.emoji_text = "🌈อย่าฟอล เดี๋ยวจน🌻รีวิวในแท็ก"
@@ -140,10 +145,20 @@ class Test_preprocess(object):
     def test_remove_hashtags(self):
         expected_result = "Saturday be like this      "
         assert_equal(remove_hashtags(self.hashtags_text), expected_result)
-    
+
     def test_remove_hashtags_with_underscore(self):
-        expected_result = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม   -19"
-        assert_equal(remove_hashtags(self.hashtags_text_with_underscore), expected_result)
+        expected_result = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม   "
+        assert_equal(
+            remove_hashtags(self.hashtags_text_with_underscore), expected_result
+        )
+
+    def test_remove_hashtags_text_with_number(self):
+        expected_result = "สวัสดีปีกุน "
+        assert_equal(remove_hashtags(self.hashtags_text_with_number), expected_result)
+
+    def test_remove_hashtags_number_with_text(self):
+        expected_result = "สวัสดีปีระกา "
+        assert_equal(remove_hashtags(self.hashtags_number_with_text), expected_result)
 
     def test_remove_tag(self):
         expected_result = "Test HTML"
@@ -187,5 +202,6 @@ class Test_preprocess(object):
 
     def test_replace_dup_emojis_with_dup_numbers(self):
         expected_result = "👧 111111 3️⃣"
-        assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
-        
+        assert_equal(
+            replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result
+        )

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -15,6 +15,7 @@ from th_preprocessor.preprocess import (
     normalize_emoji,
     normalize_haha,
     normalize_link,
+    normalize_link_with_extension,
     normalize_num,
     normalize_phone,
     normalize_special_chars,
@@ -41,6 +42,8 @@ class Test_preprocess(object):
         self.mix_text = "hey123ไม่ได้เป็นคนที่เกเรyoyo&แฮ่&&hello"
         self.unnorm_text = "เเําฤาฦา๑๒๓๔๕๖๗๘๙๐,.=\0\r\n\t\u00A0" + string.punctuation
         self.link_text = "http://www.youtube.com"
+        self.link_text_without_protocol = "google.com/search?q=hello"
+        self.link_with_extension = "https://en.wikipedia.org/wiki/Apple_Inc.#/media/File:Apple_logo_black.svg logo.svg"
         self.mention_text = "@test1234"
         self.email_text = "test_eiei_za@gmail.com"
         self.haha_text = "555555"
@@ -103,6 +106,12 @@ class Test_preprocess(object):
     def test_normalize_link(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text), expected_result)
+        expected_result = " WSLINK "
+        assert_equal(normalize_link(self.link_text_without_protocol), expected_result)
+    
+    def test_normalize_link_with_extension(self):
+        expected_result = " WSLINK   WSLINK "
+        assert_equal(normalize_link_with_extension(self.link_with_extension), expected_result)
 
     def test_normalize_at_mention(self):
         expected_result = " WSNAME "

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -13,9 +13,9 @@ from th_preprocessor.preprocess import (
     normalize_at_mention,
     normalize_email,
     normalize_emoji,
+    normalize_filename,
     normalize_haha,
     normalize_link,
-    normalize_link_with_extension,
     normalize_num,
     normalize_phone,
     normalize_special_chars,
@@ -43,7 +43,7 @@ class Test_preprocess(object):
         self.unnorm_text = "เเําฤาฦา๑๒๓๔๕๖๗๘๙๐,.=\0\r\n\t\u00A0" + string.punctuation
         self.link_text = "http://www.youtube.com"
         self.link_text_without_protocol = "google.com/search?q=hello"
-        self.link_with_extension = "https://en.wikipedia.org/wiki/Apple_Inc.#/media/File:Apple_logo_black.svg logo.svg"
+        self.filename_text = "logo.png"
         self.mention_text = "@test1234"
         self.email_text = "test_eiei_za@gmail.com"
         self.haha_text = "555555"
@@ -106,12 +106,27 @@ class Test_preprocess(object):
     def test_normalize_link(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text), expected_result)
+
+    def test_normalize_link_without_protocol(self):
         expected_result = " WSLINK "
         assert_equal(normalize_link(self.link_text_without_protocol), expected_result)
-    
-    def test_normalize_link_with_extension(self):
-        expected_result = " WSLINK   WSLINK "
-        assert_equal(normalize_link_with_extension(self.link_with_extension), expected_result)
+
+    def test_normalize_link_text_with_dot(self):
+        text = "This is a book.This is a cat."
+        expected_result = "This is a book.This is a cat."
+        assert_equal(normalize_link(text), expected_result)
+
+    def test_normalize_link_email(self):
+        text = "foo.b@gmail.com"
+        expected_result = "foo.b@gmail.com"
+        assert_equal(normalize_link(text), expected_result)
+        text = "foo_foo@gmail.com"
+        expected_result = "foo_foo@gmail.com"
+        assert_equal(normalize_link(text), expected_result)
+
+    def test_normalize_filename(self):
+        expected_result = " WSFILENAME "
+        assert_equal(normalize_filename(self.filename_text), expected_result)
 
     def test_normalize_at_mention(self):
         expected_result = " WSNAME "
@@ -191,5 +206,6 @@ class Test_preprocess(object):
 
     def test_replace_dup_emojis_with_dup_numbers(self):
         expected_result = "👧 111111 3️⃣"
-        assert_equal(replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result)
-        
+        assert_equal(
+            replace_dup_emojis(self.dup_emojis_text_with_dup_numbers), expected_result
+        )

--- a/test_preprocess.py
+++ b/test_preprocess.py
@@ -48,6 +48,7 @@ class Test_preprocess(object):
         self.special_text = "𝑇ℎ𝑒 𝑚𝑜𝑠𝑡 𝑖𝑚𝑝𝑜𝑟𝑡𝑎𝑛𝑡 𝑡ℎ𝑖𝑛𝑔 𝑖𝑠 𝑡𝑜 𝑒𝑛𝑗𝑜𝑦 น้าทุกคน"
         self.accented_text = "Cześć NESCAFÉ"
         self.hashtags_text = "Saturday be like this #pinklover #purplehair #isseymiyake #baobaoisseymiyake #baobaothailand #cafe"
+        self.hashtags_text_with_underscore = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม #covid19 #covid_19 #covid-19"
         self.tag_text = "<div>Test HTML</div>"
         self.dup_space_text = "นอนได้แล้ว\n\n\n\n\nเดี๋ยวพรุ่งนี้เขาก็กลับมา"
         self.emoji_text = "🌈อย่าฟอล เดี๋ยวจน🌻รีวิวในแท็ก"
@@ -139,6 +140,10 @@ class Test_preprocess(object):
     def test_remove_hashtags(self):
         expected_result = "Saturday be like this      "
         assert_equal(remove_hashtags(self.hashtags_text), expected_result)
+    
+    def test_remove_hashtags_with_underscore(self):
+        expected_result = "ศูนย์ฉีดวัคซีน เปิด Walk in ทุกเข็ม   -19"
+        assert_equal(remove_hashtags(self.hashtags_text_with_underscore), expected_result)
 
     def test_remove_tag(self):
         expected_result = "Test HTML"

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -45,7 +45,7 @@ RE_EXT = re.compile(
 RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
 RE_EMAIL = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b")
 RE_HAHA = re.compile(r"\b(?:ha\s*){2,}|\u0E16{3,}|5{3,}(?!.\d)\b", flags=re.IGNORECASE)
-RE_HASHTAGS = re.compile(r"#[^\s!@#$%^&*()=+.\/,\[{\]};:'\"?><]+")
+RE_HASHTAGS = re.compile(r"#[^\s]+")
 
 # Phone numbers
 phone_body_patterns = [

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -37,7 +37,7 @@ RE_LATIN = re.compile(r"[a-zA-Z0-9\s]+")
 # <tag>, http://, www., .php, @mention, mail@address.com, hahaha, 555, 1234
 # To be normalized
 RE_TAG = re.compile(r"<[^>]+>")
-RE_HTTP_WWW = re.compile(r"(?:\b\S{3,}:\/{1,}\S*)|(?:[wW]{2,}\.\S+)")
+RE_LINK = re.compile(r"((http|https)\:\/\/)?(?<![@\.])(?<=\b)[a-zA-Z0-9ก-๛\.\/\?\:\-_=#]+(\.[a-zA-Z]{2,6})([a-zA-Z0-9ก-๛\.\&\/\?\:@\-_=#]*)")
 RE_EXT = re.compile(
     r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
     flags=re.IGNORECASE,
@@ -145,9 +145,12 @@ def replace_text(text: str, replace_pairs: Iterable[Tuple[str, str]]) -> str:
 def normalize_text_pairs(text: str) -> str:
     return replace_text(text, COMBINED_NORMALIZE_PAIRS)
 
-
 def normalize_link(text: str, place_holder: str = REPLACE_LINK) -> str:
-    text = RE_HTTP_WWW.sub(place_holder, text)  # http, https, mailto, www.
+    text = RE_LINK.sub(place_holder, text)  # http, https, www.
+    return text
+
+def normalize_link_with_extension(text: str, place_holder: str = REPLACE_LINK) -> str:
+    text = RE_LINK.sub(place_holder, text)  # http, https, www.
     text = RE_EXT.sub(place_holder, text)  # .html, php3, .jpg
     return text
 
@@ -267,9 +270,9 @@ def preprocess(text: str) -> str:
     text = html.unescape(text)
     text = remove_tag(text)
 
-    text = normalize_link(text)
     text = normalize_at_mention(text)
     text = normalize_email(text)
+    text = normalize_link(text)
     text = normalize_phone(text)
     text = normalize_text_pairs(text)
     text = normalize_haha(text)

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -42,7 +42,7 @@ RE_EXT = re.compile(
     r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
     flags=re.IGNORECASE,
 )
-RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
+RE_AT_MENTION = re.compile(r"(?<=^|(?<=[^a-zA-Z0-9-_\.]))@[^\s()\[\]{}<>]+")
 RE_EMAIL = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b")
 RE_HAHA = re.compile(r"\b(?:ha\s*){2,}|\u0E16{3,}|5{3,}(?!.\d)\b", flags=re.IGNORECASE)
 RE_HASHTAGS = re.compile(r"#([a-zA-Zก-๛0-9]+[a-zA-Zก-๛0-9]*)")

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -45,7 +45,7 @@ RE_EXT = re.compile(
 RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
 RE_EMAIL = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b")
 RE_HAHA = re.compile(r"\b(?:ha\s*){2,}|\u0E16{3,}|5{3,}(?!.\d)\b", flags=re.IGNORECASE)
-RE_HASHTAGS = re.compile(r"#([a-zA-Zก-๛0-9_]+[a-zA-Zก-๛0-9_]*)")
+RE_HASHTAGS = re.compile(r"#[^\s!@#$%^&*()=+.\/,\[{\]};:'\"?><]+")
 
 # Phone numbers
 phone_body_patterns = [

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -21,6 +21,7 @@ COMBINED_NORMALIZE_PAIRS = (
 # Words to be used as replacement
 # (normalization for better classification, we hope)
 REPLACE_LINK = " WSLINK "
+REPLACE_FILENAME = " WSFILENAME "
 REPLACE_EMAIL = " WSEMAIL "
 REPLACE_AT_MENTION = " WSNAME "
 REPLACE_HAHA = " WSHAHA "
@@ -37,9 +38,9 @@ RE_LATIN = re.compile(r"[a-zA-Z0-9\s]+")
 # <tag>, http://, www., .php, @mention, mail@address.com, hahaha, 555, 1234
 # To be normalized
 RE_TAG = re.compile(r"<[^>]+>")
-RE_LINK = re.compile(r"((http|https)\:\/\/)?(?<![@\.])(?<=\b)[a-zA-Z0-9ก-๛\.\/\?\:\-_=#]+(\.[a-zA-Z]{2,6})([a-zA-Z0-9ก-๛\.\&\/\?\:@\-_=#]*)")
-RE_EXT = re.compile(
-    r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
+RE_LINK = re.compile(r"((http|https)\:\/\/)?(?<![@\.])(?<=\b)[a-zA-Z0-9ก-๛\.\/\?\:\-_=#]+(\.(?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw))(\b[a-zA-Z0-9ก-๛\.\&\/\?\:@\-_=#]*)", flags=re.IGNORECASE)
+RE_FILENAME = re.compile(
+    r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|svg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
     flags=re.IGNORECASE,
 )
 RE_AT_MENTION = re.compile(r"(?<=^|(?<=[^a-zA-Z0-9-_\.]))@[^\s()\[\]{}<>]+")
@@ -149,9 +150,8 @@ def normalize_link(text: str, place_holder: str = REPLACE_LINK) -> str:
     text = RE_LINK.sub(place_holder, text)  # http, https, www.
     return text
 
-def normalize_link_with_extension(text: str, place_holder: str = REPLACE_LINK) -> str:
-    text = RE_LINK.sub(place_holder, text)  # http, https, www.
-    text = RE_EXT.sub(place_holder, text)  # .html, php3, .jpg
+def normalize_filename(text: str, place_holder: str = REPLACE_FILENAME) -> str:
+    text = RE_FILENAME.sub(place_holder, text)  # .html, php3, .jpg
     return text
 
 
@@ -273,6 +273,7 @@ def preprocess(text: str) -> str:
     text = normalize_at_mention(text)
     text = normalize_email(text)
     text = normalize_link(text)
+    text = normalize_filename(text)
     text = normalize_phone(text)
     text = normalize_text_pairs(text)
     text = normalize_haha(text)

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -45,7 +45,7 @@ RE_EXT = re.compile(
 RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
 RE_EMAIL = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b")
 RE_HAHA = re.compile(r"\b(?:ha\s*){2,}|\u0E16{3,}|5{3,}(?!.\d)\b", flags=re.IGNORECASE)
-RE_HASHTAGS = re.compile(r"#([a-zA-Zก-๛0-9]+[a-zA-Zก-๛0-9]*)")
+RE_HASHTAGS = re.compile(r"#([a-zA-Zก-๛0-9_]+[a-zA-Zก-๛0-9_]*)")
 
 # Phone numbers
 phone_body_patterns = [

--- a/th_preprocessor/preprocess.py
+++ b/th_preprocessor/preprocess.py
@@ -21,6 +21,7 @@ COMBINED_NORMALIZE_PAIRS = (
 # Words to be used as replacement
 # (normalization for better classification, we hope)
 REPLACE_LINK = " WSLINK "
+REPLACE_FILENAME = " WSFILENAME "
 REPLACE_EMAIL = " WSEMAIL "
 REPLACE_AT_MENTION = " WSNAME "
 REPLACE_HAHA = " WSHAHA "
@@ -37,9 +38,9 @@ RE_LATIN = re.compile(r"[a-zA-Z0-9\s]+")
 # <tag>, http://, www., .php, @mention, mail@address.com, hahaha, 555, 1234
 # To be normalized
 RE_TAG = re.compile(r"<[^>]+>")
-RE_LINK = re.compile(r"((http|https)\:\/\/)?(?<![@\.])(?<=\b)[a-zA-Z0-9ก-๛\.\/\?\:\-_=#]+(\.[a-zA-Z]{2,6})([a-zA-Z0-9ก-๛\.\&\/\?\:@\-_=#]*)")
-RE_EXT = re.compile(
-    r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
+RE_LINK = re.compile(r"((http|https)\:\/\/)?(?<![@\.])(?<=\b)[a-zA-Z0-9ก-๛\.\/\?\:\-_=#]+(\.(?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw))(\b[a-zA-Z0-9ก-๛\.\&\/\?\:@\-_=#]*)", flags=re.IGNORECASE)
+RE_FILENAME = re.compile(
+    r"\w+\.(html|htm|shtm|shtml|cgi|php|php3|asp|aspx|cfm|cfml|jsp|png|gif|jpg|svg|java|class|webp|mp3|mp4|mov|pl|do)(\?\S*)?\b",
     flags=re.IGNORECASE,
 )
 RE_AT_MENTION = re.compile(r"(?:^|\s)@\S+")
@@ -149,9 +150,8 @@ def normalize_link(text: str, place_holder: str = REPLACE_LINK) -> str:
     text = RE_LINK.sub(place_holder, text)  # http, https, www.
     return text
 
-def normalize_link_with_extension(text: str, place_holder: str = REPLACE_LINK) -> str:
-    text = RE_LINK.sub(place_holder, text)  # http, https, www.
-    text = RE_EXT.sub(place_holder, text)  # .html, php3, .jpg
+def normalize_filename(text: str, place_holder: str = REPLACE_FILENAME) -> str:
+    text = RE_FILENAME.sub(place_holder, text)  # .html, php3, .jpg
     return text
 
 
@@ -273,6 +273,7 @@ def preprocess(text: str) -> str:
     text = normalize_at_mention(text)
     text = normalize_email(text)
     text = normalize_link(text)
+    text = normalize_filename(text)
     text = normalize_phone(text)
     text = normalize_text_pairs(text)
     text = normalize_haha(text)


### PR DESCRIPTION
Issue:
```
normalize_link("google.com")
>> 'google.com'
```

Fixed:
```
normalize_link("google.com")
>> ' WSLINK '
```